### PR TITLE
Bump io.papermc.paper:paper-api (#38)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.20.2-R0.1-SNAPSHOT'
 
     implementation 'com.github.CyberedCake.CyberAPI:spigot:107'
     implementation 'me.lucko:commodore:2.2'


### PR DESCRIPTION
Bumps io.papermc.paper:paper-api from 1.20.1-R0.1-SNAPSHOT to 1.20.2-R0.1-SNAPSHOT.

---
updated-dependencies:
- dependency-name: io.papermc.paper:paper-api dependency-type: direct:production update-type: version-update:semver-patch ...